### PR TITLE
Fix null/undefined property access error in executeQuery batch operations

### DIFF
--- a/src/nodes/SurrealDb/GenericFunctions.ts
+++ b/src/nodes/SurrealDb/GenericFunctions.ts
@@ -669,13 +669,9 @@ export function checkQueryResult(
             }
         }
     }
-    
+
     // Check if the result itself (not an array) has an error property
-    if (
-        result &&
-        typeof result === "object" &&
-        "error" in result
-    ) {
+    if (result && typeof result === "object" && "error" in result) {
         // Extract the error message safely
         const errorObj = result as Record<string, unknown>;
         const errorText = String(errorObj.error || "Unknown error");

--- a/src/nodes/SurrealDb/GenericFunctions.ts
+++ b/src/nodes/SurrealDb/GenericFunctions.ts
@@ -634,17 +634,50 @@ export function checkQueryResult(
     result: unknown,
     errorPrefix: string,
 ): IQueryResultCheck {
-    // Check if the result is an array and if the first element has an error property
-    const hasError =
-        Array.isArray(result) &&
-        result.length > 0 &&
-        result[0] &&
-        typeof result[0] === "object" &&
-        "error" in result[0];
+    // Check if the result is an array and look for errors in any of the result elements
+    if (Array.isArray(result) && result.length > 0) {
+        // For batch operations, we need to check each result element for errors
+        // Skip null/undefined elements and check each non-null element
+        for (const resultElement of result) {
+            if (
+                resultElement &&
+                typeof resultElement === "object" &&
+                "error" in resultElement
+            ) {
+                // Extract the error message safely
+                const errorObj = resultElement as Record<string, unknown>;
+                const errorText = String(errorObj.error || "Unknown error");
+                const errorMessage = `${errorPrefix}: ${errorText}`;
 
-    if (hasError) {
+                // Create a synthetic error for classification
+                const syntheticError = new Error(errorText);
+                const enhancedError = classifyError(syntheticError);
+
+                return {
+                    success: false,
+                    errorMessage,
+                    errorCategory: enhancedError.category,
+                    errorSeverity: enhancedError.severity,
+                    errorDetails: {
+                        originalError: errorText,
+                        resultStructure: Array.isArray(result)
+                            ? `Array with ${result.length} elements`
+                            : typeof result,
+                        timestamp: new Date().toISOString(),
+                    },
+                };
+            }
+        }
+    }
+    
+    // Check if the result itself (not an array) has an error property
+    if (
+        result &&
+        typeof result === "object" &&
+        "error" in result
+    ) {
         // Extract the error message safely
-        const errorObj = result[0] as Record<string, unknown>;
+        const errorObj = result as Record<string, unknown>;
         const errorText = String(errorObj.error || "Unknown error");
         const errorMessage = `${errorPrefix}: ${errorText}`;
 

--- a/src/nodes/SurrealDb/resources/query/operations/executeQuery.operation.ts
+++ b/src/nodes/SurrealDb/resources/query/operations/executeQuery.operation.ts
@@ -178,8 +178,9 @@ export const executeQueryOperation: IOperationHandler = {
             );
             // The result is an array of arrays, where each array contains the results of a statement
             if (Array.isArray(result)) {
-                // Process each result set, filtering out null values
-                for (const resultSet of result.filter(item => item !== null)) {
+                // Process each result set, filtering out null and undefined values
+                const filteredResults = result.filter(item => item != null);
+                for (const resultSet of filteredResults) {
                     if (Array.isArray(resultSet)) {
                         // For array results, return each item as a separate n8n item
                         const formattedResults = formatArrayResult(resultSet);


### PR DESCRIPTION
# Fix null/undefined handling in SurrealDB batch query results

Fixes the 'Cannot read properties of null (reading '...')' error that occurs when processing SurrealDB batch query results containing null/undefined elements.

## Changes
- Updated filtering logic in executeQuery.operation.ts to use loose equality (!= null) instead of strict equality (!== null) to filter out both null AND undefined values  
- Enhanced checkQueryResult function to iterate over all result elements instead of only checking the first element, properly handling batch operations

## Testing
- Verified fix works with test cases containing mixed null/undefined arrays
- Confirmed no regressions in existing functionality
- Tested in live n8n environment

Fixes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of errors across all items in batch query results, preventing missed failures.
  * Enhanced error messages with clearer details, categories, and severity to aid troubleshooting.
  * More robust handling of query results by safely ignoring null and undefined entries, reducing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->